### PR TITLE
Network disconnect resiliency

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,19 @@ UPDATE: If you decide not to install via a git clone, you can still use this scr
 ## Usage
 
 ```text
-    Usage: ./kiwix-zim.sh <h|d> /full/path/
-
-    /full/path/       Full path to ZIM directory
-
-    -d or d           Dry-Run Override
-
-    -h or h           Show this usage and exit
+    Usage: ./kiwix-zim.sh <options> /full/path/
+        /full/path/                Full path to ZIM directory
+        
+    Options:
+        -h, --help                 Show this usage and exit.
+        -c, --calculate-checksum   Verifies that the downloaded files were not corrupted, but can take a while for large downloads.
+        -d, --disable-dry-run      Dry-Run Override.
+                                   *** Caution ***
+        
+        -n <size>, --min-size      Minimum ZIM Size to be downloaded.
+                                   Specify units include M Mi G Gi, etc. See `man numfmt`
+        -x <size>, --max-size      Maximum ZIM Size to be downloaded.
+                                   Specify units include M Mi G Gi, etc. See `man numfmt`
+                                   
+        -p, --skip-purge           Skips purging any replaced ZIMs.
 ```


### PR DESCRIPTION
Changelog:

- Use some lower-overhead api calls (that is why `?F=0` exists)
- Add option to skip updating the script.
- Add option to verify library integrity. This only works for newer files, and we could make it work for older files if we cache the sha's (which are absolutely tiny) but that wont help if they didnt use this script to dl it, or the shas are missing.
- Remove curl dependency. Downloads zims with `wget`. Wget is more resilient out of the box.
- ALLOW THE USER TO `ctrl`+`c` AND CONTINUE ANY IN PROGRESS DOWNLOAD. Use the verify checksum option and let me know if you can get a failed download

It is becoming more and more apparent that the purge and download steps need to merge. I think I will do that separately and I already have a file in progress with the changes locally 

closes #15 
closes #14 (maybe, if we get consensus)