### PR TITLE
Full Docker implementation: Auto-builds, compose, documentation

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,31 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '0 0 1 * *' # Once a month
+
+jobs:
+
+  build_backend:
+    name: Build and push backend
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build and push Docker images
+      uses: docker/build-push-action@v3.3.0
+      with:
+        context: ./
+        file: ./docker/Dockerfile
+        no-cache: true
+        push: true
+        tags: ghcr.io/${{ github.repository_owner }}/kiwix-zim-updater:latest

--- a/README.md
+++ b/README.md
@@ -112,3 +112,16 @@ NOTE: if you are not tracking the `main` branch, the update check will be skippe
                                  Disable this using -S
       -S, --no-sha               Disables saving the zim checksum for future reference. Does not delete present checksums.
 ```
+
+## Running in Docker
+The updater can be run alongside the Kiwix server inside docker for regular updating. A sample [docker-compose.yml](./docker/docker-compose.yml) file is provided.
+
+The following environment options are available:
+
+|Variable|Default|Description|
+|--------|-------|-----------|
+|`TZ`|`US/Eastern`|Timezone|
+|`CRON_SCHEDULE`|`0 2 1 * *`|When to run in cron format (2AM on the first of the month)|
+|`SCRIPT_FLAGS`|`-d -w -c`|Flags for the script (no dry run, web download, calculate checksums)|
+|`UPDATE_ON_START`|`false`|Update the script on start of the container|
+|`RUN_ON_START`|`false`|Run the script on start of the container|

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,8 @@ RUN apk add \
     curl \
     wget \
     grep \
-    bash
+    bash \
+    dialog
 
 COPY kiwix-zim-updater.sh /
 COPY docker/startup.sh /

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,18 @@
+FROM alpine:latest
+
+VOLUME /data
+
+RUN apk add \
+    ca-certificates \
+    coreutils \
+    gnutls-utils \
+    curl \
+    wget \
+    grep \
+    bash
+
+COPY kiwix-zim-updater.sh /
+COPY docker/startup.sh /
+RUN chmod +x /startup.sh /kiwix-zim-updater.sh
+
+CMD ["/startup.sh"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,30 @@
+services:
+
+  kiwix:
+    image: ghcr.io/kiwix/kiwix-serve:latest
+    container_name: kiwix
+    volumes:
+      - ./data:/data
+    command: '*.zim'
+    restart: unless-stopped
+    networks:
+      - kiwix
+
+  kiwix-updater:
+    image: jojo2357/kiwix-zim-updater:latest
+    container_name: kiwix-updater
+    volumes:
+      - ./data:/data
+    environment:
+      TZ: US/Eastern             # Timezone
+      CRON_SCHEDULE: '0 2 1 * *' # 2AM on the first of the month
+      SCRIPT_FLAGS: '-d -w -c'   # No dry run, web download, calculate checksums
+      UPDATE_ON_START: true      # Update kwix-zim-updater.sh on startup
+      RUN_ON_START: false        # Run kwix-zim-updater.sh right at startup
+    restart: unless-stopped
+    networks:
+      - kiwix
+
+networks:
+  kiwix:
+    name: kiwix

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+if [ -z "${CRON_SCHEDULE}" ]; then
+    CRON_SCHEDULE='0 2 1 * *'
+fi
+
+if [ -z "${SCRIPT_FLAGS}" ]; then
+    SCRIPT_FLAGS='-d -w -c'
+fi
+
+if [ -z "${TZ}" ]; then
+    TZ='US/Eastern'
+fi
+
+if [ "${UPDATE_ON_START}" = "true" ]; then
+    curl https://raw.githubusercontent.com/jojo2357/kiwix-zim-updater/main/kiwix-zim-updater.sh -o /kiwix-zim-updater.sh &&\
+    chmod +x /kiwix-zim-updater.sh
+fi
+
+if [ "${RUN_ON_START}" = "true" ]; then
+    /bin/bash /kiwix-zim-updater.sh ${SCRIPT_FLAGS} /data
+fi
+
+echo "${CRON_SCHEDULE} /bin/bash /kiwix-zim-updater.sh ${SCRIPT_FLAGS} /data" > /crontab
+crontab /crontab
+
+echo "Running cron on schedule '${CRON_SCHEDULE}'"
+crond -f


### PR DESCRIPTION
Other PRs and forks with no PRs have attempted to implement Docker but have fallen short in specific ways:

- No provided documentation
- No cron features or no PR with them
- Downloading files when unnecessary for the build
- etc

This PR contains:
- A full Docker implementation contained within the `docker` folder
- A `Dockerfile` for building using Alpine to keep the image small
- A `docker-compose` sample for running the script automatically along side the Kiwix server
- Customization options for timezone, script flags, running on start, and the cron schedule to run
- A GitHub workflow to automatically build and push when any changes are merged into `main`, and monthly to keep the base Alpine container up to date when no changes are made
- Full documentation