### PR TITLE
Complete torrent feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Not checked or installed via script:
 A torrent client must be installed. The script will automatically determine what clients are installed, but it will prioritize use of a CLI-based client for a more hands-off execution. You can specify the client to use if you have multiple installed.
 In torrent mode, the script will automatically seed torrents until their ratio is at least 1.0 or 30 days have passed. These values are adjustable. See the `--help` option for usage.
 
-*You should consider using this method as the primary way you update ZIMs. It supports the not-for-profit ecosystem Kiwix has developed, and gives you a no-fret way to give back to the community that makes this data available.*😊
+You should consider using this method as the primary way you update ZIMs. It supports the not-for-profit ecosystem Kiwix has developed, and gives you a no-fret way to give back to the community that makes this data available.😊
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ Not checked or installed via script:
 
 - Git *(only needed for the self-update process to work.)*
 
+### If using the `--torrent` flag:
+A torrent client must be installed. The script will automatically determine what clients are installed, but it will prioritize use of a CLI-based client for a more hands-off execution. You can specify the client to use if you have multiple installed.
+In torrent mode, the script will automatically seed torrents until their ratio is at least 1.0 or 30 days have passed. These values are adjustable. See the `--help` option for usage.
+
 ## Install
 
 This script is self-updating. The self-update routine uses git commands to make the update so this script should be "installed" with the below command.

--- a/README.md
+++ b/README.md
@@ -88,31 +88,39 @@ NOTE: if you are not tracking the `main` branch, the update check will be skippe
 ## Usage
 
 ```text
+usage_example() {
   Usage: ./kiwix-zim-updater.sh <options> /full/path/
   
       /full/path/                Full path to ZIM directory
   
   Universal Options:
       -h, --help                 Show this usage and exit.
-      -d, --disable-dry-run      Dry-Run Override.
-                                 *** Caution ***   
       -u, --skip-update          Skips checking for script updates (very useful for development).
       -g, --get-index            Forces using remote index rather than cached index. Cache auto clears after one day
+      -F, --force-download       Force re-download even if file is up-to-date (for development/testing).
       -n <size>, --min-size      Minimum ZIM Size to be downloaded.
                                  Specify units include M Mi G Gi, etc. See `man numfmt`
       -x <size>, --max-size      Maximum ZIM Size to be downloaded.
-                                 Specify units include M Mi G Gi, etc. See `man numfmt`      
+                                 Specify units include M Mi G Gi, etc. See `man numfmt`
+      -S, --no-sha               Disables saving the zim checksum for future reference. Does not delete present checksums.
                                  
   Action Method Options:
       -w, --web                  Downloads zims over http(s).
-      -t, --torrent              Downloads `.torrent` files. REQUIRES ADDITIONAL SOFTWARE TO EXECUTE DOWNLOAD.
+      -t, --torrent              Downloads torrent files and starts them in a torrent client.
+      --torrent-client <n>    Specify torrent client to use
+                                 Recommended: transmission-cli, aria2c, transmission-remote
+                                 GUI clients (qbittorrent, deluge) require user interaction
+      --seed-ratio <ratio>       Stop seeding when ratio reaches value (default: 1.0) [Only with CLI torrent clients]
+      --seed-time <minutes>      Stop seeding after minutes (default: 43200 = 30 days) [Only with CLI torrent clients]
       
+      -f, --verify-library       Verifies that the entire library has the correct checksums as found online.
+                                 Expected behavior is to create sha256 files during a normal run so this option can be used at a later date without internet.
+                                 Disable this using -S
+  
   Web Download Options:
       -c, --calculate-checksum   Verifies that the downloaded files were not corrupted, but can take a while for large downloads.
       -p, --skip-purge           Skips purging any replaced ZIMs.
       -l <location>, --location  Country Code to prefer mirrors from
-      -f, --verify-library       Verifies that the entire library has the correct checksums as found online.
-                                 Expected behavior is to create sha256 files during a normal run so this option can be used at a later date without internet.
-                                 Disable this using -S
-      -S, --no-sha               Disables saving the zim checksum for future reference. Does not delete present checksums.
+      -d, --disable-dry-run      Dry-Run Override.
+                                 *** Caution ***
 ```

--- a/README.md
+++ b/README.md
@@ -114,7 +114,8 @@ usage_example() {
       --seed-time <minutes>      Stop seeding after minutes (default: 43200 = 30 days) [Only with CLI torrent clients]
       
       -f, --verify-library       Verifies that the entire library has the correct checksums as found online.
-                                 Expected behavior is to create sha256 files during a normal run so this option can be used at a later date without internet.
+                                 Expected behavior is to create sha256 files during a normal run so this option can be used at
+                                 a later date without internet.
                                  Disable this using -S
   
   Web Download Options:

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Not checked or installed via script:
 A torrent client must be installed. The script will automatically determine what clients are installed, but it will prioritize use of a CLI-based client for a more hands-off execution. You can specify the client to use if you have multiple installed.
 In torrent mode, the script will automatically seed torrents until their ratio is at least 1.0 or 30 days have passed. These values are adjustable. See the `--help` option for usage.
 
+*You should consider using this method as the primary way you update ZIMs. It supports the not-for-profit ecosystem Kiwix has developed, and gives you a no-fret way to give back to the community that makes this data available.*😊
+
 ## Install
 
 This script is self-updating. The self-update routine uses git commands to make the update so this script should be "installed" with the below command.

--- a/kiwix-zim-updater.sh
+++ b/kiwix-zim-updater.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VER="3.3-torrent-mod"
+VER="3.4"
 
 # This array will contain all of the local zims, with the file extension
 LocalZIMArray=()


### PR DESCRIPTION
This PR has a bunch of changes. 
Lots added around the torrent feature. Before these commits, the --torrent option didn't work. It would download the .torrent files but after that, nothing happened.

I have added the following significant changes:

1. Actively search for and download appropriate torrents for ZIMs which need updated.
2. Detect torrent clients available on the machine.
3. Prioritize CLI-based torrent clients (such as aria2c) to improve automation.
4. Allow torrent client to be selected by the user and bypass the script's automatic priority. *If a GUI client is selected, automatic download folder selection, seed ratio and seed time will no longer apply.*
5. Configured a default maximum seed-ratio and seed-time so the automatic torrenting doesn't hit-and-run. (Be nice, seed your torrents!)
6. Added a `--force-update` feature for development testing.
7. Fixed a bug where `--max-size` wasn't respected if running `--force-update`

I believe Torrenting files for this purpose is important. Kiwix is not for profit, and I think we should support that venture by helping them host the files for everyone. Bandwidth costs money and it's not fair to make them bear that load.