### PR TITLE
Fix Kiwix catalog mirror URL parsing

### DIFF
--- a/kiwix-zim-updater.sh
+++ b/kiwix-zim-updater.sh
@@ -83,7 +83,7 @@ master_scrape() {
   IFS=$'\n' read -r -d '' -a FileSizes < <(echo "$RawLibrary" | grep -ioP '(?<=length=")\d+(?=")')
   unset IFS
 
-  hrefs=$(echo "$RawLibrary" | grep -ioP "(?<=href=\")[\w:\/\-.]+(?=\.meta4\")" | grep -ioP "$BaseURL\K.*")
+  hrefs=$(echo "$RawLibrary" | grep -ioP '(?<=href=")(https?://[^"]+)?/zim/[\w:\/\-.]+(?=\.meta4")' | grep -ioP '/zim/\K.*')
 
   IFS=$'\n' read -r -d '' -a RemoteFiles < <(echo "$hrefs" | grep -ioP "[^/]/\K[\w:\/\-.]+")
   unset IFS

--- a/kiwix-zim.sh
+++ b/kiwix-zim.sh
@@ -83,7 +83,7 @@ master_scrape() {
   IFS=$'\n' read -r -d '' -a FileSizes < <(echo "$RawLibrary" | grep -ioP '(?<=length=")\d+(?=")')
   unset IFS
 
-  hrefs=$(echo "$RawLibrary" | grep -ioP "(?<=href=\")[\w:\/\-.]+(?=\.meta4\")" | grep -ioP "$BaseURL\K.*")
+  hrefs=$(echo "$RawLibrary" | grep -ioP '(?<=href=")(https?://[^"]+)?/zim/[\w:\/\-.]+(?=\.meta4")' | grep -ioP '/zim/\K.*')
 
   IFS=$'\n' read -r -d '' -a RemoteFiles < <(echo "$hrefs" | grep -ioP "[^/]/\K[\w:\/\-.]+")
   unset IFS


### PR DESCRIPTION
## Summary
The base URL for the ZIM downloads changed. The previous parser only accepted URLs beginning with the hard-coded `https://download.kiwix.org/zim/` base URL. Current catalog entries can use alternate Kiwix mirror hosts, which caused the script to discard every remote ZIM entry and exit with:

`✗ Could not find any remote files, exiting`

## Changes
- Parse catalog `href` values from any HTTP(S) host as long as the path is under `/zim/`.
- Preserve the existing relative path format used by the rest of the script.
- Apply the same fix to both `kiwix-zim-updater.sh` and deprecated `kiwix-zim.sh`.

## Testing
Tested on Linux (Synology)

Before this change, the script exited with no remote files found. After this change, it found `3473` online files, matched the local test ZIM, and detected the available update.




